### PR TITLE
support ctrl key for non-macOS platforms

### DIFF
--- a/src/Pane.html
+++ b/src/Pane.html
@@ -37,7 +37,7 @@
 	export default {
 		methods: {
 			handleMousedown(node, event) {
-				if (!event.metaKey) return;
+				if (!event.ctrlKey && !event.metaKey) return;
 
 				const { top, right, bottom, left } = node.getBoundingClientRect();
 				const { items } = this.get();

--- a/src/Subdivide.html
+++ b/src/Subdivide.html
@@ -11,7 +11,7 @@
 	{/each}
 
 	{#each _dividers as divider (divider.id)}
-		<Divider {divider} on:mousedown="set({ _dragging: !event.metaKey && divider })"/>
+		<Divider {divider} on:mousedown="set({ _dragging: !event.ctrlKey && !event.metaKey && divider })"/>
 	{/each}
 </div>
 


### PR DESCRIPTION
Supporting either ctrl or meta on macOS or non-macOS seems fine to me, I don't really see a need to check the platform and then check only ctrlKey or only metaKey.