### PR TITLE
Simplify panes

### DIFF
--- a/src/Subdivide.html
+++ b/src/Subdivide.html
@@ -310,22 +310,14 @@
 
 				const bounds = _dragging.parent.bounds(this.refs.container.getBoundingClientRect());
 
-				const prev = _dragging.prev;
-				const next = _dragging.next;
+				const { prev, next } = _dragging;
 
-				let min;
-				let max;
-				let position;
+				const min = prev.pos;
+				const max = next.pos + next.size;
 
-				if (_dragging.type === 'vertical') {
-					min = prev.pos;
-					max = next.pos + next.size;
-					position = clamp((event.clientX - bounds.left) / bounds.width, min, max);
-				} else {
-					min = prev.pos;
-					max = next.pos + next.size;
-					position = clamp((event.clientY - bounds.top) / bounds.height, min, max);
-				}
+				const position = _dragging.type === 'vertical'
+					? clamp((event.clientX - bounds.left) / bounds.width, min, max)
+					: clamp((event.clientY - bounds.top) / bounds.height, min, max);
 
 				prev.setRange(min, position);
 				next.setRange(position, max);

--- a/src/Subdivide.html
+++ b/src/Subdivide.html
@@ -69,7 +69,7 @@
 		root: {
 			id: 0,
 			type: 'group',
-			direction: constants.COLUMN,
+			row: false,
 			x: 0,
 			y: 0,
 			w: 1,
@@ -126,7 +126,7 @@
 				let maxid = 0;
 
 				const createGroup = data => {
-					const group = new Group(data.id, data.direction, {
+					const group = new Group(data.id, data.row, {
 						x: data.x,
 						y: data.y,
 						w: data.w,
@@ -140,8 +140,8 @@
 					let lastChild = null;
 
 					data.children.sort((a, b) => {
-						if (group.type === constants.COLUMN) return a.y - b.y;
-						return a.x - b.x;
+						if (group.row) return a.x - b.x;
+						return a.y - b.y;
 					}).forEach((data, i) => {
 						let child;
 
@@ -169,7 +169,7 @@
 							child.prev = lastChild;
 							lastChild.next = child;
 
-							const dividerType = group.type === constants.COLUMN ? 'horizontal' : 'vertical';
+							const dividerType = group.row ? 'vertical' : 'horizontal';
 
 							const divider = new Divider({
 								id: _did++,
@@ -222,15 +222,13 @@
 					? 'horizontal'
 					: 'vertical';
 
-				const groupType = dividerType === 'horizontal'
-					? constants.COLUMN
-					: constants.ROW;
+				const childGroupIsRow = dividerType === 'vertical';
 
 				let group = pane.parent;
 
-				const newGroup = group && group.type === groupType
+				const newGroup = group && group.row === childGroupIsRow
 					? null
-					: new Group(_pid++, groupType, pane);
+					: new Group(_pid++, childGroupIsRow, pane);
 
 				if (newGroup) {
 					pane.x = pane.y = 0;
@@ -259,22 +257,7 @@
 					next: null
 				});
 
-				if (groupType === constants.COLUMN) {
-					const y = (clientY - bounds.top) / bounds.height;
-					const d = y - pane.y;
-
-					divider.position = y;
-
-					if (edge === constants.NORTH) {
-						newPane.h = d;
-						pane.y = y;
-						pane.h -= d;
-					} else {
-						newPane.y = y;
-						newPane.h = pane.h - d;
-						pane.h  = d;
-					}
-				} else {
+				if (childGroupIsRow) {
 					const x = (clientX - bounds.left) / bounds.width;
 					const d = x - pane.x;
 
@@ -288,6 +271,21 @@
 						newPane.x = x;
 						newPane.w = pane.w - d;
 						pane.w  = d;
+					}
+				} else {
+					const y = (clientY - bounds.top) / bounds.height;
+					const d = y - pane.y;
+
+					divider.position = y;
+
+					if (edge === constants.NORTH) {
+						newPane.h = d;
+						pane.y = y;
+						pane.h -= d;
+					} else {
+						newPane.y = y;
+						newPane.h = pane.h - d;
+						pane.h  = d;
 					}
 				}
 

--- a/src/Subdivide.html
+++ b/src/Subdivide.html
@@ -70,20 +70,16 @@
 			id: 0,
 			type: 'group',
 			row: false,
-			x: 0,
-			y: 0,
-			w: 1,
-			h: 1,
+			pos: 0,
+			size: 1,
 			prev: null,
 			next: null,
 			children: [
 				{
 					type: 'pane',
 					id: 1,
-					x: 0,
-					y: 0,
-					w: 1,
-					h: 1,
+					pos: 0,
+					size: 1,
 					prev: null,
 					next: null
 				}
@@ -127,10 +123,8 @@
 
 				const createGroup = data => {
 					const group = new Group(data.id, data.row, {
-						x: data.x,
-						y: data.y,
-						w: data.w,
-						h: data.h,
+						pos: data.pos,
+						size: data.size,
 						prev: null,
 						next: null
 					});
@@ -140,8 +134,7 @@
 					let lastChild = null;
 
 					data.children.sort((a, b) => {
-						if (group.row) return a.x - b.x;
-						return a.y - b.y;
+						return a.pos - b.pos;
 					}).forEach((data, i) => {
 						let child;
 
@@ -151,10 +144,8 @@
 							child = createGroup(data);
 						} else {
 							child = new Pane(data.id, {
-								x: data.x,
-								y: data.y,
-								w: data.w,
-								h: data.h,
+								pos: data.pos,
+								size: data.size,
 								prev: null,
 								next: null
 							});
@@ -175,7 +166,7 @@
 								id: _did++,
 								type: dividerType,
 								group,
-								position: dividerType === 'horizontal' ? child.y : child.x,
+								position: child.pos,
 								prev: lastChild,
 								next: child
 							});
@@ -231,8 +222,8 @@
 					: new Group(_pid++, childGroupIsRow, pane);
 
 				if (newGroup) {
-					pane.x = pane.y = 0;
-					pane.w = pane.h = 1;
+					pane.pos = 0;
+					pane.size = 1;
 
 					pane.parent.replaceChild(pane, newGroup);
 					group = newGroup;
@@ -259,22 +250,22 @@
 
 				if (childGroupIsRow) {
 					const x = (clientX - bounds.left) / bounds.width;
-					const d = x - pane.x;
+					const d = x - pane.pos;
 
 					divider.position = x;
 
 					if (edge === constants.WEST) {
-						newPane.w = d;
-						pane.x = x;
-						pane.w -= d;
+						newPane.size = d;
+						pane.pos = x;
+						pane.size -= d;
 					} else {
-						newPane.x = x;
-						newPane.w = pane.w - d;
-						pane.w  = d;
+						newPane.pos = x;
+						newPane.size = pane.size - d;
+						pane.size  = d;
 					}
 				} else {
 					const y = (clientY - bounds.top) / bounds.height;
-					const d = y - pane.y;
+					const d = y - pane.pos;
 
 					divider.position = y;
 
@@ -345,12 +336,12 @@
 				let position;
 
 				if (_dragging.type === 'vertical') {
-					min = prev.x;
-					max = next.x + next.w;
+					min = prev.pos;
+					max = next.pos + next.size;
 					position = clamp((event.clientX - bounds.left) / bounds.width, min, max);
 				} else {
-					min = prev.y;
-					max = next.y + next.h;
+					min = prev.pos;
+					max = next.pos + next.size;
 					position = clamp((event.clientY - bounds.top) / bounds.height, min, max);
 				}
 
@@ -368,13 +359,9 @@
 
 				this.drag(event);
 
-				const prevSize = _dragging.type === 'vertical'
-					? _dragging.prev.w
-					: _dragging.prev.h;
+				const prevSize = _dragging.prev.size;
 
-				const min = Math.min(prevSize, _dragging.type === 'vertical'
-					? _dragging.next.w
-					: _dragging.next.h)
+				const min = Math.min(prevSize, _dragging.next.size);
 
 				if (min < 0.0001) {
 					removeFromArray(_dragging.parent.dividers, _dragging);

--- a/src/Subdivide.html
+++ b/src/Subdivide.html
@@ -133,9 +133,7 @@
 
 					let lastChild = null;
 
-					data.children.sort((a, b) => {
-						return a.pos - b.pos;
-					}).forEach((data, i) => {
+					data.children.sort((a, b) => a.pos - b.pos).forEach((data, i) => {
 						let child;
 
 						if (data.id > maxid) maxid = data.id;
@@ -248,39 +246,19 @@
 					next: null
 				});
 
-				if (childGroupIsRow) {
-					const x = (clientX - bounds.left) / bounds.width;
-					const d = x - pane.pos;
+				const pos = childGroupIsRow
+					? (clientX - bounds.left) / bounds.width
+					: (clientY - bounds.top) / bounds.height;
 
-					divider.position = x;
+				const d = pos - pane.pos;
 
-					if (edge === constants.WEST) {
-						newPane.size = d;
-						pane.pos = x;
-						pane.size -= d;
-					} else {
-						newPane.pos = x;
-						newPane.size = pane.size - d;
-						pane.size  = d;
-					}
-				} else {
-					const y = (clientY - bounds.top) / bounds.height;
-					const d = y - pane.pos;
-
-					divider.position = y;
-
-					if (edge === constants.NORTH) {
-						newPane.h = d;
-						pane.y = y;
-						pane.h -= d;
-					} else {
-						newPane.y = y;
-						newPane.h = pane.h - d;
-						pane.h  = d;
-					}
-				}
+				divider.position = pos;
 
 				if (edge === constants.NORTH || edge === constants.WEST) {
+					newPane.size = d;
+					pane.pos = pos;
+					pane.size -= d;
+
 					if (pane.prev) pane.prev.next = newPane;
 
 					pane.prev = divider;
@@ -289,6 +267,10 @@
 					divider.prev = newPane;
 					divider.next = pane;
 				} else {
+					newPane.pos = pos;
+					newPane.size = pane.size - d;
+					pane.size = d;
+
 					if (pane.next) pane.next.prev = newPane;
 
 					pane.next = divider;

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,8 +3,5 @@ export const SOUTH = 'SOUTH';
 export const EAST = 'EAST';
 export const WEST = 'WEST';
 
-export const HORIZONTAL = 'HORIZONTAL';
-export const VERTICAL = 'VERTICAL';
-
 export const IS_MAC = navigator.platform === 'MacIntel';
 export const KEYCODE = IS_MAC ? 91 : 17; // Cmd : Ctrl

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,8 +6,5 @@ export const WEST = 'WEST';
 export const HORIZONTAL = 'HORIZONTAL';
 export const VERTICAL = 'VERTICAL';
 
-export const COLUMN = 'COLUMN';
-export const ROW = 'ROW';
-
 export const IS_MAC = navigator.platform === 'MacIntel';
 export const KEYCODE = IS_MAC ? 91 : 17; // Cmd : Ctrl

--- a/src/elements.js
+++ b/src/elements.js
@@ -1,5 +1,3 @@
-import * as constants from './constants.js';
-
 class Rect {
 	constructor(id, x, y, w, h, prev, next) {
 		this.id = id;
@@ -8,10 +6,25 @@ class Rect {
 		this.w = w;
 		this.h = h;
 
+		// this.pos = x || y;
+		// this.size = w === 1 ? h : w;
+
 		this.prev = prev;
 		this.next = next;
 
 		this.parent = null;
+	}
+
+	get pos() {
+		return this.parent
+			? this.parent.row ? this.x : this.y
+			: 0;
+	}
+
+	get size() {
+		return this.parent
+			? this.parent.row ? this.w : this.h
+			: 1;
 	}
 
 	bounds(rect) {
@@ -26,40 +39,44 @@ class Rect {
 		};
 	}
 
-	getLeft() {
-		let left = this.x;
+	getPos(row) {
+		let pos = 0;
 
 		let node = this;
-		while (node = node.parent) left = node.x + (node.w * left);
+		while (node.parent) {
+			if (node.parent.row === row) pos = node.pos + (node.size * pos);
+			node = node.parent;
+		}
 
-		return left;
+		return pos;
+	}
+
+	getLeft() {
+		return this.getPos(true);
 	}
 
 	getTop() {
-		let top = this.y;
+		return this.getPos(false);
+	}
+
+	getSize(row) {
+		let size = 1;
 
 		let node = this;
-		while (node = node.parent) top = node.y + (node.h * top);
+		while (node.parent) {
+			if (node.parent.row === row) size *= node.size;
+			node = node.parent;
+		}
 
-		return top;
+		return size;
 	}
 
 	getWidth() {
-		let width = this.w;
-
-		let node = this;
-		while (node = node.parent) width *= node.w;
-
-		return width;
+		return this.getSize(true);
 	}
 
 	getHeight() {
-		let height = this.h;
-
-		let node = this;
-		while (node = node.parent) height *= node.h;
-
-		return height;
+		return this.getSize(false);
 	}
 
 	setRange(a, b) {
@@ -104,7 +121,6 @@ export class Group extends Rect {
 		super(id, x, y, w, h, prev, next);
 
 		this.row = row;
-		this.type = row ? 'ROW' : 'COLUMN';
 		this.children = [];
 		this.dividers = [];
 	}

--- a/src/elements.js
+++ b/src/elements.js
@@ -1,30 +1,13 @@
 class Rect {
-	constructor(id, x, y, w, h, prev, next) {
+	constructor(id, pos, size, prev, next) {
 		this.id = id;
-		this.x = x;
-		this.y = y;
-		this.w = w;
-		this.h = h;
-
-		// this.pos = x || y;
-		// this.size = w === 1 ? h : w;
+		this.pos = pos;
+		this.size = size;
 
 		this.prev = prev;
 		this.next = next;
 
 		this.parent = null;
-	}
-
-	get pos() {
-		return this.parent
-			? this.parent.row ? this.x : this.y
-			: 0;
-	}
-
-	get size() {
-		return this.parent
-			? this.parent.row ? this.w : this.h
-			: 1;
 	}
 
 	bounds(rect) {
@@ -80,19 +63,14 @@ class Rect {
 	}
 
 	setRange(a, b) {
-		if (this.parent.row) {
-			this.x = a;
-			this.w = (b - a);
-		} else {
-			this.y = a;
-			this.h = (b - a);
-		}
+		this.pos = a;
+		this.size = (b - a);
 	}
 }
 
 export class Pane extends Rect {
-	constructor(id, { x, y, w, h, prev, next }) {
-		super(id, x, y, w, h, prev, next);
+	constructor(id, { pos, size, prev, next }) {
+		super(id, pos, size, prev, next);
 		this.id = id;
 	}
 
@@ -106,10 +84,8 @@ export class Pane extends Rect {
 		return {
 			id: this.id,
 			type: 'pane',
-			x: this.x,
-			y: this.y,
-			w: this.w,
-			h: this.h,
+			pos: this.pos,
+			size: this.size,
 			prev: this.prev && this.prev.id,
 			next: this.next && this.next.id
 		};
@@ -117,8 +93,8 @@ export class Pane extends Rect {
 }
 
 export class Group extends Rect {
-	constructor(id, row, { x, y, w, h, prev, next }) {
-		super(id, x, y, w, h, prev, next);
+	constructor(id, row, { pos, size, prev, next }) {
+		super(id, pos, size, prev, next);
 
 		this.row = row;
 		this.children = [];
@@ -154,10 +130,8 @@ export class Group extends Rect {
 			id: this.id,
 			type: 'group',
 			row: this.row,
-			x: this.x,
-			y: this.y,
-			w: this.w,
-			h: this.h,
+			pos: this.pos,
+			size: this.size,
 			prev: this.prev && this.prev.id,
 			next: this.next && this.next.id,
 			children: this.children.map(child => child.toJSON())

--- a/src/elements.js
+++ b/src/elements.js
@@ -63,12 +63,12 @@ class Rect {
 	}
 
 	setRange(a, b) {
-		if (this.parent.type === constants.COLUMN) {
-			this.y = a;
-			this.h = (b - a);
-		} else {
+		if (this.parent.row) {
 			this.x = a;
 			this.w = (b - a);
+		} else {
+			this.y = a;
+			this.h = (b - a);
 		}
 	}
 }
@@ -100,10 +100,11 @@ export class Pane extends Rect {
 }
 
 export class Group extends Rect {
-	constructor(id, type, { x, y, w, h, prev, next }) {
+	constructor(id, row, { x, y, w, h, prev, next }) {
 		super(id, x, y, w, h, prev, next);
 
-		this.type = type;
+		this.row = row;
+		this.type = row ? 'ROW' : 'COLUMN';
 		this.children = [];
 		this.dividers = [];
 	}
@@ -136,7 +137,7 @@ export class Group extends Rect {
 		return {
 			id: this.id,
 			type: 'group',
-			direction: this.type, // TODO confusing
+			row: this.row,
 			x: this.x,
 			y: this.y,
 			w: this.w,

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -559,7 +559,7 @@ test('accepts a layout', t => {
 		root: {
 			id: 0,
 			type: 'group',
-			direction: 'COLUMN',
+			row: false,
 			x: 0,
 			y: 0,
 			w: 1,

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -560,30 +560,24 @@ test('accepts a layout', t => {
 			id: 0,
 			type: 'group',
 			row: false,
-			x: 0,
-			y: 0,
-			w: 1,
-			h: 1,
+			pos: 0,
+			size: 1,
 			prev: null,
 			next: null,
 			children: [
 				{
 					type: 'pane',
 					id: 1,
-					x: 0,
-					y: 0,
-					w: 1,
-					h: 0.5,
+					pos: 0,
+					size: 0.5,
 					prev: null,
 					next: null
 				},
 				{
 					type: 'pane',
-					id: 1,
-					x: 0,
-					y: 0.5,
-					w: 1,
-					h: 0.5,
+					id: 2,
+					pos: 0.5,
+					size: 0.5,
 					prev: null,
 					next: null
 				}


### PR DESCRIPTION
Replaces `x`, `y`, `w` and `h` with `pos` and `size`, since the additional properties are redundant.